### PR TITLE
hide template from public facing docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '_static']
+exclude_patterns = ['_build', '_static', 'content/stories/template*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/content/stories/index.rst
+++ b/docs/content/stories/index.rst
@@ -15,7 +15,6 @@ Stories
 .. toctree::
     :maxdepth: 2
 
-    template
     TKC_DC_story
 
 .. _SimPEG: http://simpeg.xyz


### PR DESCRIPTION
remove the "my story" template from public facing docs. Still present in the content as an rst that can be copied
